### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,6 +1,8 @@
 # This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
 # See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
 name: CMake on multiple platforms
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kgorking/gbs/security/code-scanning/1](https://github.com/kgorking/gbs/security/code-scanning/1)

To fix the problem, add a top-level `permissions:` block after the workflow `name:` and before `jobs:`. This block should explicitly declare the minimum permissions the workflow requires. For a CMake build/test workflow, only reading the repository contents is necessary, so the correct permissions block is:

```yaml
permissions:
  contents: read
```

This should be inserted on a new line after the `name:` key (line 3), and before the `on:` key (line 5), so that it applies globally to all jobs (since the workflow has only one job, `build`). No other changes, imports, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
